### PR TITLE
Add support for additional file types via `any-json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ajv-cli
 
 Command line interface for [ajv](https://github.com/epoberezkin/ajv), one of the [fastest json schema validators](https://github.com/ebdrup/json-schema-benchmark).
+Supports [JSON](http://json.org/), [JSON5](http://json5.org/), and [YAML](http://yaml.org/). 
 
 [![Build Status](https://travis-ci.org/jessedc/ajv-cli.svg?branch=master)](https://travis-ci.org/jessedc/ajv-cli)
 [![npm](https://img.shields.io/npm/v/ajv-cli.svg)](https://www.npmjs.com/package/ajv-cli)

--- a/commands/util.js
+++ b/commands/util.js
@@ -3,6 +3,8 @@
 var glob = require('glob');
 var path = require('path');
 var fs = require('fs');
+var yaml = require('js-yaml');
+var JSON5 = require('json5');
 
 
 module.exports = {
@@ -30,12 +32,33 @@ function getFiles(args) {
 }
 
 
+function getFormatFromFileName(filename) {
+    return path.extname(filename).substr(1).toLowerCase();
+}
+
+
+function decodeFile(contents, format) {
+    switch(format) {
+        case 'json':
+            return JSON.parse(contents);
+        case 'json5':
+            return JSON5.parse(contents);
+        case 'yml':
+        case 'yaml':
+            return yaml.safeLoad(contents);
+        default:
+            throw new Error('unsupported format ' + format);
+    }
+}
+
+
 function openFile(filename, suffix){
     var json = null;
     var file = path.resolve(process.cwd(), filename);
     try {
         try {
-            json = JSON.parse(fs.readFileSync(file).toString());
+            var format = getFormatFromFileName(filename);
+            json = decodeFile(fs.readFileSync(file).toString(), format);
         } catch(JSONerr) {
             json = require(file);
         }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "ajv-pack": "^0.3.0",
     "fast-json-patch": "^2.0.0",
     "glob": "^7.1.0",
+    "js-yaml": "^3.13.1",
     "json-schema-migrate": "^0.2.0",
+    "json5": "^2.1.3",
     "minimist": "^1.2.0"
   },
   "devDependencies": {

--- a/test/invalid_format.cson
+++ b/test/invalid_format.cson
@@ -1,0 +1,40 @@
+# Comments!!!
+
+# An Array with no commas!
+greatDocumentaries: [
+	'earthlings.com'
+	'forksoverknives.com'
+	'cowspiracy.com'
+]
+
+# An Object without braces!
+importantFacts:
+	# Multi-Line Strings! Without Quote Escaping!
+	emissions: '''
+		Livestock and their byproducts account for at least 32,000 million tons of carbon dioxide (CO2) per year, or 51% of all worldwide greenhouse gas emissions.
+		Goodland, R Anhang, J. “Livestock and Climate Change: What if the key actors in climate change were pigs, chickens and cows?”
+		WorldWatch, November/December 2009. Worldwatch Institute, Washington, DC, USA. Pp. 10–19.
+		http://www.worldwatch.org/node/6294
+		'''
+
+	landuse: '''
+		Livestock covers 45% of the earth’s total land.
+		Thornton, Phillip, Mario Herrero, and Polly Ericksen. “Livestock and Climate Change.” Livestock Exchange, no. 3 (2011).
+		https://cgspace.cgiar.org/bitstream/handle/10568/10601/IssueBrief3.pdf
+		'''
+
+	burger: '''
+		One hamburger requires 660 gallons of water to produce – the equivalent of 2 months’ worth of showers.
+		Catanese, Christina. “Virtual Water, Real Impacts.” Greenversations: Official Blog of the U.S. EPA. 2012.
+		http://blog.epa.gov/healthywaters/2012/03/virtual-water-real-impacts-world-water-day-2012/
+		“50 Ways to Save Your River.” Friends of the River.
+		http://www.friendsoftheriver.org/site/PageServer?pagename=50ways
+		'''
+
+	milk: '''
+		1,000 gallons of water are required to produce 1 gallon of milk.
+		“Water trivia facts.” United States Environmental Protection Agency.
+		http://water.epa.gov/learn/kids/drinkingwater/water_trivia_facts.cfm#_edn11
+		'''
+
+	more: 'http://cowspiracy.com/facts'

--- a/test/valid_data.json5
+++ b/test/valid_data.json5
@@ -1,0 +1,32 @@
+[
+    // todo: we're missing item 1
+    {
+        id: 2,
+        name: 'An ice sculpture',
+        price: 12.50,
+        tags: ['cold', 'ice'],
+        dimensions: {
+            length: 7.0,
+            width: 12.0,
+            height: 9.5
+        },
+        warehouseLocation: {
+            latitude: -78.75,
+            longitude: 20.4
+        }
+    },
+    {
+        id: 3,
+        name: 'A blue mouse',
+        price: 25.50,
+        dimensions: {
+            length: 3.1,
+            width: 1.0,
+            height: 1.0
+        },
+        warehouseLocation: {
+            latitude: 54.4,
+            longitude: -32.7
+        }
+    }
+]

--- a/test/valid_data.yaml
+++ b/test/valid_data.yaml
@@ -1,0 +1,23 @@
+- id: 2
+  name: An ice sculpture
+  price: 12.5
+  tags:
+    - cold
+    - ice
+  dimensions:
+    length: 7
+    width: 12
+    height: 9.5
+  warehouseLocation:
+    latitude: -78.75
+    longitude: 20.4
+- id: 3
+  name: A blue mouse
+  price: 25.5
+  dimensions:
+    length: 3.1
+    width: 1
+    height: 1
+  warehouseLocation:
+    latitude: 54.4
+    longitude: -32.7

--- a/test/valid_data.yml
+++ b/test/valid_data.yml
@@ -1,0 +1,23 @@
+- id: 2
+  name: An ice sculpture
+  price: 12.5
+  tags:
+    - cold
+    - ice
+  dimensions:
+    length: 7
+    width: 12
+    height: 9.5
+  warehouseLocation:
+    latitude: -78.75
+    longitude: 20.4
+- id: 3
+  name: A blue mouse
+  price: 25.5
+  dimensions:
+    length: 3.1
+    width: 1
+    height: 1
+  warehouseLocation:
+    latitude: 54.4
+    longitude: -32.7

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -17,6 +17,33 @@ describe('validate', function() {
       });
     });
 
+    it('should validate valid data with the "yml" extension', function(done) {
+      cli('-s test/schema -d test/valid_data.yml', function(error, stdout, stderr) {
+        assert.strictEqual(error, null);
+        assertValid(stdout, 1);
+        assert.equal(stderr, '');
+        done();
+      });
+    });
+
+    it('should validate valid data with the "yaml" extension', function(done) {
+      cli('-s test/schema -d test/valid_data.yaml', function(error, stdout, stderr) {
+        assert.strictEqual(error, null);
+        assertValid(stdout, 1);
+        assert.equal(stderr, '');
+        done();
+      });
+    });
+
+    it('should validate valid data with the "json5" extension', function(done) {
+      cli('-s test/schema -d test/valid_data.json5', function(error, stdout, stderr) {
+        assert.strictEqual(error, null);
+        assertValid(stdout, 1);
+        assert.equal(stderr, '');
+        done();
+      });
+    });
+
     it('should validate invalid data', function (done) {
       cli('-s test/schema.json -d test/invalid_data.json --errors=line', function (error, stdout, stderr) {
         assert(error instanceof Error);

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -44,6 +44,15 @@ describe('validate', function() {
       });
     });
 
+    it('falls back to require on unsupported formats', function (done) {
+      cli('-s test/schema.json -d test/invalid_format.cson --errors=line', function (error, stdout, stderr) {
+        assert(error instanceof Error);
+        assert.equal(stdout, '');
+        assert.ok(/Invalid or unexpected token/i.exec(stderr));
+        done();
+      });
+    });
+
     it('should validate invalid data', function (done) {
       cli('-s test/schema.json -d test/invalid_data.json --errors=line', function (error, stdout, stderr) {
         assert(error instanceof Error);


### PR DESCRIPTION
It all works pretty well considering; I've adjusted it so that it shouldn't be a breaking change - i.e you can still use a javascript file.

Not too happy about `deasync-promise`, since it's binary package, but I think this a good first step.

To eliminate it, `ajv-cli` would need to be refactored to use promises - it's not a big change, but it's a knock on effect that requires the whole general chain of methods to be touched, so I'd prefer to get a thumbs up before sinking time into.

Resolves #61 