### PR TITLE
Allow strict-mode options

### DIFF
--- a/commands/options.js
+++ b/commands/options.js
@@ -16,6 +16,9 @@ var AJV_OPTIONS = {
     'all-errors':       { type: 'boolean' },
     'verbose':          { type: 'boolean' },
     'json-pointers':    { type: 'boolean' },
+    'strict-keywords':  { type: 'boolean' },
+    'strict-defaults':   { type: 'boolean'},
+    'strict-numbers':    { type: 'boolean'},
     'unique-items':     { type: 'boolean' },
     'unicode':          { type: 'boolean' },
     'format':           { anyOf: [


### PR DESCRIPTION
ajv-cli currently does not allow setting the strict-mode options to be passed on to ajv.

These are required to flag unknown keywords as errors. 

Usage example:

ajv compile --all-errors --json-pointers --strict-keywords -s mySchema.json

With the "--strict-keywords" option, the 'unwanted_keyword' will be flagged as invalid in the following example schema.
Without it it will be missed.
```
...
  "attributes": {
        "type": "object",
        "properties": {
          "valid_property": {
            "title": "A title",
            "type": "string"
          },
          "unwanted_keyword": "Should raise an error"
        }
      },
...
```