### PR TITLE
feat: fallback to `json5` parse if file extension is not recognised

### DIFF
--- a/commands/util.js
+++ b/commands/util.js
@@ -41,13 +41,12 @@ function decodeFile(contents, format) {
     switch(format) {
         case 'json':
             return JSON.parse(contents);
+        default:
         case 'json5':
             return JSON5.parse(contents);
         case 'yml':
         case 'yaml':
             return yaml.safeLoad(contents);
-        default:
-            throw new Error('unsupported format ' + format);
     }
 }
 

--- a/test/schema.schema
+++ b/test/schema.schema
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "schema.json",
+    "description": "basic schema from z-schema benchmark (https://github.com/zaggino/z-schema)",
+    "title": "Product set",
+    "type": "array",
+    "items": {
+        "title": "Product",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "id": {
+                "description": "The unique identifier for a product",
+                "type": "number"
+            },
+            "name": {
+                "type": "string"
+            },
+            "price": {
+                "type": "number",
+                "exclusiveMinimum": 0
+            },
+            "tags": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "minItems": 1,
+                "uniqueItems": true
+            },
+            "dimensions": {
+                "type": "object",
+                "properties": {
+                    "length": {"type": "number"},
+                    "width": {"type": "number"},
+                    "height": {"type": "number"}
+                },
+                "required": ["length", "width", "height"]
+            },
+            "warehouseLocation": {
+                "description": "Coordinates of the warehouse with the product"
+            }
+        },
+        "required": ["id", "name", "price"]
+    }
+}

--- a/test/valid_data.data
+++ b/test/valid_data.data
@@ -1,0 +1,32 @@
+[
+    // todo: we're missing item 1
+    {
+        id: 2,
+        name: 'An ice sculpture',
+        price: 12.50,
+        tags: ['cold', 'ice'],
+        dimensions: {
+            length: 7.0,
+            width: 12.0,
+            height: 9.5
+        },
+        warehouseLocation: {
+            latitude: -78.75,
+            longitude: 20.4
+        }
+    },
+    {
+        id: 3,
+        name: 'A blue mouse',
+        price: 25.50,
+        dimensions: {
+            length: 3.1,
+            width: 1.0,
+            height: 1.0
+        },
+        warehouseLocation: {
+            latitude: 54.4,
+            longitude: -32.7
+        }
+    }
+]

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -44,7 +44,16 @@ describe('validate', function() {
       });
     });
 
-    it('falls back to require on unsupported formats', function (done) {
+    it('falls back to json5 when the extension is not recognised', function(done) {
+      cli('-s test/schema.schema -d test/valid_data.data', function(error, stdout, stderr) {
+        assert.strictEqual(error, null);
+        assertValid(stdout, 1);
+        assert.equal(stderr, '');
+        done();
+      });
+    });
+
+    it('falls back to require if parsing fails', function (done) {
       cli('-s test/schema.json -d test/invalid_format.cson --errors=line', function (error, stdout, stderr) {
         assert(error instanceof Error);
         assert.equal(stdout, '');


### PR DESCRIPTION
Fixes #77