### PR TITLE
Set `$data` option in the presence of the `--data` switch

### DIFF
--- a/src/commands/options.ts
+++ b/src/commands/options.ts
@@ -94,7 +94,10 @@ function parameter(str: string): string {
 export function getOptions(argv: ParsedArgs): Options & {code: CodeOptions} {
   const options: {[K in string]: any} = {code: {}}
   for (let opt in ajvOptions) {
-    if (opt === "data") opt = "$data"
+    if (opt === "data") {
+      opt = "$data"
+      argv.$data = argv.data
+    }
     const value = argv[toDashCase(opt)] ?? argv[opt]
     if (value === undefined) continue
     if (opt.startsWith(CODE)) {

--- a/test/data_for_schema_with_data_reference.json
+++ b/test/data_for_schema_with_data_reference.json
@@ -1,0 +1,4 @@
+{
+  "larger": 20,
+  "smaller": 10
+}

--- a/test/schema_with_data_reference.json
+++ b/test/schema_with_data_reference.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "schema_with_data.json",
+  "description": "schema to test $data references",
+  "type": "object",
+  "properties": {
+    "larger": {
+      "type": "number",
+      "minimum": {
+        "$data": "1/smaller"
+      }
+    },
+    "smaller": {
+      "type": "number"
+    }
+  }
+}

--- a/test/validate.spec.ts
+++ b/test/validate.spec.ts
@@ -232,6 +232,34 @@ describe("validate", function () {
     })
   })
 
+  describe('option "data"', () => {
+    it("should exit with error when not specified in the presence of `$data` references", (done) => {
+      cli(
+        "validate -s test/schema_with_data_reference -d test/data_for_schema_with_data_reference",
+        (error, stdout, stderr) => {
+          assert(error instanceof Error)
+          assert.strictEqual(stdout, "")
+          assert(stderr.includes("test/schema_with_data_reference is invalid"))
+          assert(stderr.includes("larger/minimum"))
+          assert(stderr.includes("should be number"))
+          done()
+        }
+      )
+    })
+
+    it("it should enable `$data` references when specified", (done) => {
+      cli(
+        "validate --data -s test/schema_with_data_reference -d test/data_for_schema_with_data_reference",
+        (error, stdout, stderr) => {
+          assert.strictEqual(error, null)
+          assertValid(stdout, 1)
+          assert.strictEqual(stderr, "")
+          done()
+        }
+      )
+    })
+  })
+
   describe("custom keywords", () => {
     it("should validate valid data; custom keyword definition in file", (done) => {
       cli(


### PR DESCRIPTION
I have applied the fix as proposed in #93. I have also included some basic tests around the behavior as, looking through the issues, it looks like this is behavior that has been prone to breaking in the past as well.

Fixes #93.