### PR TITLE
Read yaml files with CORE_SCHEMA

### DIFF
--- a/src/commands/util.ts
+++ b/src/commands/util.ts
@@ -35,7 +35,7 @@ function decodeFile(contents: string, format: string): any {
       return JSON5.parse(contents)
     case "yml":
     case "yaml":
-      return yaml.safeLoad(contents)
+      return yaml.safeLoad(contents, {schema: yaml.CORE_SCHEMA})
     default:
       throw new Error(`unsupported file format ${format}`)
   }


### PR DESCRIPTION
Date-time related formats in ajv-formats expects string data
type, but js-yaml by default reads yamls with full type yaml
support. That means that dates are read as strings and therefore
the values are invalid in terms of ajv-formats format

Fixes #122