### PR TITLE
validate support ajv-i18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "ajv": "^8.0.0",
+    "ajv-i18n": "^4.0.0",
     "fast-json-patch": "^2.0.0",
     "glob": "^7.1.0",
     "js-yaml": "^3.14.0",

--- a/src/commands/i18n.ts
+++ b/src/commands/i18n.ts
@@ -1,0 +1,18 @@
+import * as localizeJtd from "ajv-i18n/localize/jtd"
+import * as localize from "ajv-i18n"
+import {ParsedArgs} from "minimist"
+
+export function i18n(argv: ParsedArgs, errors: any): any {
+  if (process.env.AVJ_I18N) {
+    const langTag = process.env.AVJ_I18N
+    const l: any = argv.spec === "jtd" ? localizeJtd : localize
+    const f = l[langTag]
+    if (f) {
+      f(errors)
+    } else {
+      console.error(`${langTag} not found in ajv-i18n`)
+    }
+  }
+
+  return errors
+}

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -3,6 +3,7 @@ import type {ParsedArgs} from "minimist"
 import {compile, getFiles, openFile, logJSON} from "./util"
 import getAjv from "./ajv"
 import * as jsonPatch from "fast-json-patch"
+import {i18n} from "./i18n"
 
 const cmd: Command = {
   execute,
@@ -54,7 +55,7 @@ function execute(argv: ParsedArgs): boolean {
       }
     } else {
       console.error(file, "invalid")
-      console.error(logJSON(argv.errors, validate.errors, ajv))
+      console.error(logJSON(argv.errors, i18n(argv, validate.errors), ajv))
     }
     return validData
   }


### PR DESCRIPTION
use by set env `AVJ_I18N`

invoke like this:
```
AVJ_I18N=zh ajv validate --strict=false -s conf-schema.json -d xxxx.yml
```

test:
![image](https://user-images.githubusercontent.com/3535204/121655742-69fb8900-cad1-11eb-962b-4725d0c43476.png)

