### PR TITLE
Add `draft2020` to supported schema versions in `help`

### DIFF
--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -58,7 +58,8 @@ function schemaSpecOption(): void {
 options:
     --spec=            JSON schema specification to use
             draft7     JSON Schema draft-07 (default)
-            draft2019  JSON Schema draft-2019-09`)
+            draft2019  JSON Schema draft-2019-09
+            draft2020  JSON Schema draft-2020-12`)
 }
 
 function helpValidate(): void {

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -59,7 +59,8 @@ options:
     --spec=            JSON schema specification to use
             draft7     JSON Schema draft-07 (default)
             draft2019  JSON Schema draft-2019-09
-            draft2020  JSON Schema draft-2020-12`)
+            draft2020  JSON Schema draft-2020-12
+            jtd        JSON Type Definition`)
 }
 
 function helpValidate(): void {


### PR DESCRIPTION
As `draft2020` is supported, we should make it clear in the output from
our `help` subcommand.
