### PR TITLE
fix: avoid loading schemas in -r that exist in -s

### DIFF
--- a/src/commands/util.ts
+++ b/src/commands/util.ts
@@ -51,7 +51,7 @@ export function openFile(filename: string, suffix: string): any {
     } catch (e) {
       json = require(file)
     }
-  } catch (err) {
+  } catch (err: any) {
     const msg: string = err.message
     console.error(`error:  ${msg.replace(" module", " " + suffix)}`)
     process.exit(2)
@@ -80,7 +80,7 @@ export function compile(ajv: Ajv, schemaFile: string): AnyValidateFunction {
   const schema = openFile(schemaFile, "schema")
   try {
     return ajv.compile(schema)
-  } catch (err) {
+  } catch (err: any) {
     console.error(`schema ${schemaFile} is invalid`)
     console.error(`error: ${err.message}`)
     process.exit(1)

--- a/test/models/dependency.json
+++ b/test/models/dependency.json
@@ -1,0 +1,16 @@
+{
+  "$id": "dependency.json",
+
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+
+    "root": {
+      "$ref": "./root.json"
+    }
+  },
+
+  "type": "object",
+  "additionalProperties": false
+}

--- a/test/models/root.json
+++ b/test/models/root.json
@@ -1,0 +1,16 @@
+{
+  "$id": "root.json",
+
+  "properties": {
+    "dependency": {
+      "$ref": "./dependency.json"
+    },
+
+    "root": {
+      "$ref": "./root.json"
+    }
+  },
+
+  "type": "object",
+  "additionalProperties": false
+}

--- a/test/models/valid_data.jsonc
+++ b/test/models/valid_data.jsonc
@@ -1,0 +1,5 @@
+{
+   "dependency": {
+     "name": "Hello World"
+   }
+ }

--- a/test/validate.spec.ts
+++ b/test/validate.spec.ts
@@ -181,6 +181,19 @@ describe("validate", function () {
       })
     })
 
+    // See https://github.com/ajv-validator/ajv-cli/issues/172.
+    it("should resolve references that are also provided via the primary schema", (done) => {
+      cli(
+          '-s test/models/root.json -r "test/models/*.json" -d test/models/valid_data.jsonc',
+          (error, stdout, stderr) => {
+              assert.strictEqual(error, null)
+              assertValid(stdout, 1)
+              assert.strictEqual(stderr, "")
+              done()
+          }
+      )
+    })
+
     it("should resolve reference and validate invalid data", (done) => {
       cli(
         "-s test/schema_with_ref -r test/schema -d test/invalid_data --errors=line",


### PR DESCRIPTION
Similar approach as the open pr #190 but avoids changes to the logJSON function

Builds and `npm test` runs locally