### PR TITLE
Add `--code-esm` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ You can pass the following [Ajv options](https://ajv.js.org/options.html):
 | `--own-properties` | only validate own properties (not relevant for JSON, but can have effect for JavaScript objects) |
 | Code generation |
 | `--code-es5` | generate ES5 code |
+| `--code-esm` | generate ESM code |
 | `--code-lines` | generate multi-line code |
 | `--code-optimize=` | disable optimization (`false`) or number of optimization passes (1 pass by default) |
 | `--code-formats=` | code to require formats object (only needed if you generate standalone code and do not use [ajv-formats](https://github.com/ajv-validator/ajv-formats)) |

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -234,7 +234,9 @@ Ajv options (see https://github.com/epoberezkin/ajv#options):
     
     --own-properties   only validate own properties (not relevant for JSON, but can have effect for JavaScript objects)
     
-    --code-es5         generate ES5 code
+    --code-es5         generate ES5 code    
+
+    --code-esm         generate ESM code
 
     --code-lines       generate multi-line code
 

--- a/src/commands/options.ts
+++ b/src/commands/options.ts
@@ -26,6 +26,7 @@ const ajvOptions: SchemaMap = {
   multipleOfPrecision: boolOrNat,
   messages: {type: "boolean"},
   [`${CODE}es5`]: {type: "boolean"},
+  [`${CODE}esm`]: {type: "boolean"},
   [`${CODE}lines`]: {type: "boolean"},
   [`${CODE}optimize`]: boolOrNat,
   [`${CODE}formats`]: {type: "string"},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "allowJs": true,
     "target": "ES2018",
     "resolveJsonModule": true,
-    "esModuleInterop": false
+    "esModuleInterop": false,
+    "useUnknownInCatchVariables": false
   }
 }


### PR DESCRIPTION
As of [ajv@8.9.0](https://github.com/ajv-validator/ajv/releases/tag/v8.9.0), compiling to esm is now supported. This PR allows that functionality to be accessed.