### PR TITLE
feat: add --code-esm option

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ You can pass the following [Ajv options](https://ajv.js.org/options.html):
 | `--own-properties` | only validate own properties (not relevant for JSON, but can have effect for JavaScript objects) |
 | Code generation |
 | `--code-es5` | generate ES5 code |
+| `--code-esm` | generate ESM exported code |
 | `--code-lines` | generate multi-line code |
 | `--code-optimize=` | disable optimization (`false`) or number of optimization passes (1 pass by default) |
 | `--code-formats=` | code to require formats object (only needed if you generate standalone code and do not use [ajv-formats](https://github.com/ajv-validator/ajv-formats)) |

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -236,6 +236,8 @@ Ajv options (see https://github.com/epoberezkin/ajv#options):
     
     --code-es5         generate ES5 code
 
+    --code-esm         generate ESM exported code
+
     --code-lines       generate multi-line code
 
     --code-optimize=   code optimization

--- a/src/commands/options.ts
+++ b/src/commands/options.ts
@@ -26,6 +26,7 @@ const ajvOptions: SchemaMap = {
   multipleOfPrecision: boolOrNat,
   messages: {type: "boolean"},
   [`${CODE}es5`]: {type: "boolean"},
+  [`${CODE}esm`]: {type: "boolean"},
   [`${CODE}lines`]: {type: "boolean"},
   [`${CODE}optimize`]: boolOrNat,
   [`${CODE}formats`]: {type: "string"},


### PR DESCRIPTION
A `--code-esm` option is [mentioned in the documentation](https://ajv.js.org/standalone.html#validating-multiple-schemas-using-the-js-library-es6-and-esm), but doesn't seem to have been added to the CLI – this PR adds the option and updates the readme/help info.