### PR TITLE
Correct anchor ID in ToC link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Supports [JSON](http://json.org/), [JSON5](http://json5.org/), and [YAML](http:/
   - [Migrate schemas](#migrate-schemas)
   - [Test validation result](#test-validation-result)
 - [Ajv options](#ajv-options)
-- [Version History, License](#version_history)
+- [Version History, License](#version-history)
 
 ## Installation
 


### PR DESCRIPTION
GitHub automatically generates anchors for every heading in a Markdown file. The hyphen is used as a replacement character in the generated anchor ID.

The "Version History, License" item in the readme table of contents erroneously used an underscore rather than hyphen as the replacement character in the fragment, which caused the link to be non-functional.

Link before:

- https://ajv.js.org/packages/ajv-cli.html#version_history
- https://github.com/ajv-validator/ajv-cli#version_history

Link after:

- https://ajv.js.org/packages/ajv-cli.html#version-history
- https://github.com/ajv-validator/ajv-cli#version-history