### PR TITLE
fix: correctly handle yml with duplicate keys

### DIFF
--- a/src/commands/util.ts
+++ b/src/commands/util.ts
@@ -35,7 +35,7 @@ function decodeFile(contents: string, format: string): any {
       return JSON5.parse(contents)
     case "yml":
     case "yaml":
-      return yaml.safeLoad(contents, {schema: yaml.CORE_SCHEMA})
+      return yaml.safeLoad(contents, {schema: yaml.CORE_SCHEMA, json: true})
     default:
       throw new Error(`unsupported file format ${format}`)
   }


### PR DESCRIPTION
JS-YAML fails to parse YAML in to JS when duplicate keys exist due to JS object restrictions, this uses JSON parse option for JS-YAML to prevent JS-YAML from throwing out during safeload of the YML file. 

Fixes #211 

Ref: https://github.com/nodeca/js-yaml/issues/591