### PR TITLE
fix(#43): Load all schemas before validating them

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
     "ts-node": "^9.1.0",
-    "typescript": "^4.1.2"
+    "typescript": "4.1.2"
   },
   "peerDependencies": {
     "ts-node": ">=9.0.0"


### PR DESCRIPTION
Hello! This PR ensures that all of the schemas passed through the CLI are loaded before they're validated, allowing schemas to cross reference each other without having to be loaded in a given order 👍 