### PR TITLE
Add -x option to "validate" for files to ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ These modules can be written in TypeScript if you have `ts-node` installed.
 
 For example, you can use `-c ajv-keywords` to add all keywords from [ajv-keywords](https://github.com/ajv-validator/ajv-keywords) package or `-c ajv-keywords/keywords/typeof` to add only typeof keyword.
 
+##### `-x` - exclude data files
+
+If the files matched by the `-d` glob pattern(s) are too broad, an ignore pattern can be added using `-x`.  This pattern is passed directly to the [glob library](https://github.com/isaacs/node-glob#options) as the `ignore` option.  Only a single ignore pattern can be specified, but it can be quite flexible:
+
+```sh
+ajv -s test/schema.json -d test/*.json -x "test/+(schema|legacy-*).json"
+```
+
 #### Options
 
 - `--errors=`: error reporting format. Possible values:

--- a/src/commands/ajv.ts
+++ b/src/commands/ajv.ts
@@ -84,7 +84,7 @@ export default function (argv: ParsedArgs): AjvCore {
 
     try {
       registerer = require("ts-node").register()
-    } catch (err) {
+    } catch (err: any) {
       /* istanbul ignore next */
       if (err.code === "MODULE_NOT_FOUND") {
         throw new Error(

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -70,9 +70,11 @@ parameters
     -r referenced schema(s)
     -m meta schema(s)
     -c custom keywords/formats definitions
+    -x data file pattern to be ignored
 
     -d, -r, -m, -c can be globs and can be used multiple times
     glob should be enclosed in double quotes
+    -x can only be used once, but can be a glob
     -c module(s) should export a function that accepts Ajv instance as parameter
     (file path should start with ".", otherwise used as require package)
     .json extension can be omitted (but should be used in globs)`)

--- a/src/commands/util.ts
+++ b/src/commands/util.ts
@@ -6,7 +6,7 @@ import * as yaml from "js-yaml"
 import * as JSON5 from "json5"
 import {AnyValidateFunction} from "ajv/dist/core"
 
-export function getFiles(args: string | string[]): string[] {
+export function getFiles(args: string | string[], ignore?: string): string[] {
   let files: string[] = []
   if (Array.isArray(args)) args.forEach(_getFiles)
   else _getFiles(args)
@@ -14,7 +14,7 @@ export function getFiles(args: string | string[]): string[] {
 
   function _getFiles(fileOrPattern: string): void {
     if (glob.hasMagic(fileOrPattern)) {
-      const dataFiles = glob.sync(fileOrPattern, {cwd: process.cwd()})
+      const dataFiles = glob.sync(fileOrPattern, {cwd: process.cwd(), ignore})
       files = files.concat(dataFiles)
     } else {
       files.push(fileOrPattern)
@@ -51,7 +51,7 @@ export function openFile(filename: string, suffix: string): any {
     } catch (e) {
       json = require(file)
     }
-  } catch (err) {
+  } catch (err: any) {
     const msg: string = err.message
     console.error(`error:  ${msg.replace(" module", " " + suffix)}`)
     process.exit(2)
@@ -80,7 +80,7 @@ export function compile(ajv: Ajv, schemaFile: string): AnyValidateFunction {
   const schema = openFile(schemaFile, "schema")
   try {
     return ajv.compile(schema)
-  } catch (err) {
+  } catch (err: any) {
     console.error(`schema ${schemaFile} is invalid`)
     console.error(`error: ${err.message}`)
     process.exit(1)

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -18,6 +18,9 @@ const cmd: Command = {
       r: {$ref: "#/$defs/stringOrArray"},
       m: {$ref: "#/$defs/stringOrArray"},
       c: {$ref: "#/$defs/stringOrArray"},
+      x: {
+        type: "string",
+      },
       errors: {enum: ["json", "line", "text", "js", "no"]},
       changes: {enum: [true, "json", "line", "js"]},
       spec: {enum: ["draft7", "draft2019", "draft2020", "jtd"]},
@@ -31,7 +34,7 @@ export default cmd
 function execute(argv: ParsedArgs): boolean {
   const ajv = getAjv(argv)
   const validate = compile(ajv, argv.s)
-  return getFiles(argv.d)
+  return getFiles(argv.d, argv.x)
     .map(validateDataFile)
     .every((x) => x)
 


### PR DESCRIPTION
Adds an option `-x` to "validate" that will be passed as the `ignore`
property in the glob options.  It can only be provided once, but can be
any valid glob pattern.