### PR TITLE
Allow `validate` command to save validation results to file

### DIFF
--- a/src/commands/ajv.ts
+++ b/src/commands/ajv.ts
@@ -85,13 +85,14 @@ export default function (argv: ParsedArgs): AjvCore {
     try {
       registerer = require("ts-node").register()
     } catch (err) {
-      /* istanbul ignore next */
-      if (err.code === "MODULE_NOT_FOUND") {
-        throw new Error(
-          `'ts-node' is required for the TypeScript configuration files. Make sure it is installed\nError: ${err.message}`
-        )
+      if (err instanceof Error) {
+        /* istanbul ignore next */
+        if ((err as any).code === "MODULE_NOT_FOUND") {
+          throw new Error(
+            `'ts-node' is required for the TypeScript configuration files. Make sure it is installed\nError: ${err.message}`
+          )
+        }
       }
-
       throw err
     }
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -70,6 +70,7 @@ parameters
     -r referenced schema(s)
     -m meta schema(s)
     -c custom keywords/formats definitions
+    -o output file to save any validation results
 
     -d, -r, -m, -c can be globs and can be used multiple times
     glob should be enclosed in double quotes

--- a/src/commands/util.ts
+++ b/src/commands/util.ts
@@ -52,8 +52,10 @@ export function openFile(filename: string, suffix: string): any {
       json = require(file)
     }
   } catch (err) {
-    const msg: string = err.message
-    console.error(`error:  ${msg.replace(" module", " " + suffix)}`)
+    if (err instanceof Error) {
+      const msg: string = err.message
+      console.error(`error:  ${msg.replace(" module", " " + suffix)}`)
+    }
     process.exit(2)
   }
   return json
@@ -81,8 +83,10 @@ export function compile(ajv: Ajv, schemaFile: string): AnyValidateFunction {
   try {
     return ajv.compile(schema)
   } catch (err) {
-    console.error(`schema ${schemaFile} is invalid`)
-    console.error(`error: ${err.message}`)
+    if (err instanceof Error) {
+      console.error(`schema ${schemaFile} is invalid`)
+      console.error(`error: ${err.message}`)
+    }
     process.exit(1)
   }
 }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -3,6 +3,7 @@ import type {ParsedArgs} from "minimist"
 import {compile, getFiles, openFile, logJSON} from "./util"
 import getAjv from "./ajv"
 import * as jsonPatch from "fast-json-patch"
+import * as fs from "fs"
 
 const cmd: Command = {
   execute,
@@ -18,6 +19,7 @@ const cmd: Command = {
       r: {$ref: "#/$defs/stringOrArray"},
       m: {$ref: "#/$defs/stringOrArray"},
       c: {$ref: "#/$defs/stringOrArray"},
+      o: {type: "string", format: "notGlob"},
       errors: {enum: ["json", "line", "text", "js", "no"]},
       changes: {enum: [true, "json", "line", "js"]},
       spec: {enum: ["draft7", "draft2019", "draft2020", "jtd"]},
@@ -54,7 +56,11 @@ function execute(argv: ParsedArgs): boolean {
       }
     } else {
       console.error(file, "invalid")
-      console.error(logJSON(argv.errors, validate.errors, ajv))
+      if (argv.o) {
+        fs.writeFileSync(argv.o, JSON.stringify(validate.errors))
+      } else {
+        console.error(logJSON(argv.errors, validate.errors, ajv))
+      }
     }
     return validData
   }

--- a/test/validate.spec.ts
+++ b/test/validate.spec.ts
@@ -1,5 +1,6 @@
 import cli from "./cli"
 import assert = require("assert")
+import fs = require("fs")
 import type {DefinedError} from "ajv"
 
 describe("validate", function () {
@@ -344,6 +345,25 @@ describe("validate", function () {
           assert.strictEqual(err.keyword, "typeof")
           assert.strictEqual(err.instancePath, "")
           assert.strictEqual(err.schemaPath, "#/typeof")
+          done()
+        }
+      )
+    })
+
+    it("should validate invalid data to output file", (done) => {
+      cli(
+        "validate -s test/custom/schema -c ajv-keywords/dist/keywords/typeof -d test/custom/invalid_data -o test/validate_schema.json",
+        (error, stdout, stderr) => {
+          const validate = require("./validate_schema.json")
+          fs.unlinkSync("test/validate_schema.json")
+          assert(error instanceof Error)
+          assert.strictEqual(stdout, "")
+          assert.strictEqual(stderr, "test/custom/invalid_data invalid\n")
+          assert.strictEqual(1, validate.length)
+          const validateOutput = validate[0]
+          assert.strictEqual(validateOutput.schemaPath, "#/typeof")
+          assert.strictEqual(validateOutput.keyword, "typeof")
+          assert.strictEqual(validateOutput.message, `must pass "typeof" keyword validation`)
           done()
         }
       )


### PR DESCRIPTION
* added support for saving ajv validation results to a file
* adds -o flag to validate function
* adds testing for generated file