### PR TITLE
Parse all schemas as JSON

### DIFF
--- a/src/commands/ajv.ts
+++ b/src/commands/ajv.ts
@@ -84,7 +84,7 @@ export default function (argv: ParsedArgs): AjvCore {
 
     try {
       registerer = require("ts-node").register()
-    } catch (err) {
+    } catch (err: any) {
       /* istanbul ignore next */
       if (err.code === "MODULE_NOT_FOUND") {
         throw new Error(

--- a/src/commands/ajv.ts
+++ b/src/commands/ajv.ts
@@ -49,7 +49,7 @@ export default function (argv: ParsedArgs): AjvCore {
     if (!args) return
     const files = util.getFiles(args)
     files.forEach((file) => {
-      const schema = util.openFile(file, fileType)
+      const schema = util.openFile(file, fileType, "json")
       try {
         ajv[method](schema)
       } catch (err) {

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -47,7 +47,7 @@ function execute(argv: ParsedArgs): boolean {
   }
 
   function compileSchema(file: string): AnyValidateFunction | undefined {
-    const sch = openFile(file, `schema ${file}`)
+    const sch = openFile(file, `schema ${file}`, "json")
     try {
       const id = sch?.$id
       ajv.addSchema(sch, id ? undefined : file)

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -33,7 +33,7 @@ function execute(argv: ParsedArgs): boolean {
   return schemaFiles.map(migrateSchema).every((x) => x)
 
   function migrateSchema(file: string): boolean {
-    const sch = openFile(file, `schema ${file}`)
+    const sch = openFile(file, `schema ${file}`, "json")
     const migratedSchema: AnySchemaObject = JSON.parse(JSON.stringify(sch))
     const spec = (argv.spec || "draft7") as JSONSchemaDraft
     migrate[spec](migratedSchema)

--- a/src/commands/util.ts
+++ b/src/commands/util.ts
@@ -50,7 +50,7 @@ export function openFile(filename: string, suffix: string, format?: string): any
     } catch (e) {
       json = require(file)
     }
-  } catch (err) {
+  } catch (err: any) {
     const msg: string = err.message
     console.error(`error:  ${msg.replace(" module", " " + suffix)}`)
     process.exit(2)
@@ -79,7 +79,7 @@ export function compile(ajv: Ajv, schemaFile: string): AnyValidateFunction {
   const schema = openFile(schemaFile, "schema", "json")
   try {
     return ajv.compile(schema)
-  } catch (err) {
+  } catch (err: any) {
     console.error(`schema ${schemaFile} is invalid`)
     console.error(`error: ${err.message}`)
     process.exit(1)

--- a/src/commands/util.ts
+++ b/src/commands/util.ts
@@ -41,13 +41,12 @@ function decodeFile(contents: string, format: string): any {
   }
 }
 
-export function openFile(filename: string, suffix: string): any {
+export function openFile(filename: string, suffix: string, format?: string): any {
   let json = null
   const file = path.resolve(process.cwd(), filename)
   try {
     try {
-      const format = getFormatFromFileName(filename)
-      json = decodeFile(fs.readFileSync(file).toString(), format)
+      json = decodeFile(fs.readFileSync(file).toString(), format ?? getFormatFromFileName(filename))
     } catch (e) {
       json = require(file)
     }
@@ -77,7 +76,7 @@ export function logJSON(mode: string, data: any, ajv?: Ajv): string {
 }
 
 export function compile(ajv: Ajv, schemaFile: string): AnyValidateFunction {
-  const schema = openFile(schemaFile, "schema")
+  const schema = openFile(schemaFile, "schema", "json")
   try {
     return ajv.compile(schema)
   } catch (err) {


### PR DESCRIPTION
Always reading as JSON means that you can use [process substitution](https://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html) for validating schemas since it can't infer the format from the file descriptor.

```sh
ajv-cli validate -s <(curl -sSL https://json.schemastore.org/package.json) -d package.json
```

The same could be useful as an additional flag for the data so you could choose json5 or yaml as the type for a process substitution, but I haven't included that here.